### PR TITLE
Disable PayPal processing in Google Payment when the configuration does not supply a Client ID

### DIFF
--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.braintreepayments.api.exceptions.BraintreeException;
 import com.braintreepayments.api.exceptions.ErrorWithResponse;
@@ -499,21 +500,26 @@ public class GooglePayment {
                     buildCardPaymentMethodParameters(request, fragment));
         }
 
-        if (request.isPayPalEnabled() &&
-                configuration.isPayPalEnabled() &&
-                request.getAllowedPaymentMethod("PAYPAL") == null) {
-            request.setAllowedPaymentMethod(PAYPAL_PAYMENT_TYPE,
-                    buildPayPalPaymentMethodParameters(fragment));
-        }
-
         if (request.getTokenizationSpecificationForType(CARD_PAYMENT_TYPE) == null) {
             request.setTokenizationSpecificationForType("CARD",
                     buildCardTokenizationSpecification(fragment));
         }
 
-        if (request.getTokenizationSpecificationForType(PAYPAL_PAYMENT_TYPE) == null) {
-            request.setTokenizationSpecificationForType("PAYPAL",
-                    buildPayPalTokenizationSpecification(fragment));
+        boolean googlePaymentCanProcessPayPal = request.isPayPalEnabled() &&
+                configuration.isPayPalEnabled() &&
+                !TextUtils.isEmpty(configuration.getPayPal().getClientId());
+
+        if (googlePaymentCanProcessPayPal) {
+            if (request.getAllowedPaymentMethod("PAYPAL") == null) {
+                request.setAllowedPaymentMethod(PAYPAL_PAYMENT_TYPE,
+                        buildPayPalPaymentMethodParameters(fragment));
+            }
+
+
+            if (request.getTokenizationSpecificationForType(PAYPAL_PAYMENT_TYPE) == null) {
+                request.setTokenizationSpecificationForType("PAYPAL",
+                        buildPayPalTokenizationSpecification(fragment));
+            }
         }
 
         request.environment(configuration.getAndroidPay().getEnvironment());

--- a/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import static com.braintreepayments.api.test.FixturesHelper.stringFromFixture;
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 

--- a/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
@@ -121,7 +121,6 @@ public class TestConfigurationBuilder extends JSONBuilder {
             if (enabled) {
                 environment("test");
                 displayName("displayName");
-                clientId("clientId");
                 privacyUrl("http://privacy.gov");
                 userAgreementUrl("http://i.agree.biz");
             }


### PR DESCRIPTION
Google Payment requires the PayPal Client ID to process PayPal payments.

If the PayPal configuration does not return this property we should disable PayPal processing in Google Payment.