### PR TITLE
Resolve issue where optional shipping parameters were required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Google Pay SDK Release Notes
 
+## Unreleased
+
+* Resolve issue where optional shipping parameters were treated as if they were required
+
 ## 3.0.0
 
 * Convert to AndroidX

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/GooglePaymentRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/GooglePaymentRequest.java
@@ -224,26 +224,19 @@ public class GooglePaymentRequest implements Parcelable {
         JSONArray allowedPaymentMethods = new JSONArray();
         JSONObject shippingAddressParameters = new JSONObject();
         JSONArray allowedCountryCodes = new JSONArray();
-        ArrayList<String> allowedCountryCodeList = new ArrayList<>();
-
-        if (mShippingAddressRequirements != null) {
-            allowedCountryCodeList.addAll(mShippingAddressRequirements.getAllowedCountryCodes());
-
-            if (allowedCountryCodeList.size() > 0) {
-                for (String country : allowedCountryCodeList) {
-                    allowedCountryCodes
-                            .put(country);
-                }
-            }
-        }
+        ArrayList<String> allowedCountryCodeList;
 
         if (isShippingAddressRequired()) {
-            try {
-                shippingAddressParameters
-                        .put("allowedCountryCodes", allowedCountryCodes)
-                        .put("phoneNumberRequired", isPhoneNumberRequired());
-            } catch (JSONException ignored) {
+            allowedCountryCodeList = mShippingAddressRequirements.getAllowedCountryCodes();
+
+            if (allowedCountryCodeList != null && allowedCountryCodeList.size() > 0) {
+                try {
+                    shippingAddressParameters.put("allowedCountryCodes", new JSONArray(allowedCountryCodeList));
+                } catch (JSONException ignored) { }
             }
+            try {
+                shippingAddressParameters.put("phoneNumberRequired", isPhoneNumberRequired());
+            } catch (JSONException ignored) { }
         }
 
         try {

--- a/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
@@ -226,4 +226,26 @@ public class GooglePaymentRequestUnitTest {
 
         JSONAssert.assertEquals(expected, actual, false);
     }
+
+    @Test
+    public void allowsNullyOptionalParameters() throws JSONException {
+        GooglePaymentRequest request = new GooglePaymentRequest();
+        String expected = "{\"apiVersion\":2,\"apiVersionMinor\":0,\"allowedPaymentMethods\":[],\"shippingAddressRequired\":true,\"merchantInfo\":{},\"transactionInfo\":{\"totalPriceStatus\":\"FINAL\",\"totalPrice\":\"12.24\",\"currencyCode\":\"USD\"},\"shippingAddressParameters\":{}}";
+
+        ShippingAddressRequirements nullyShippingAddressRequirements = ShippingAddressRequirements.newBuilder().build();
+
+        TransactionInfo info = TransactionInfo.newBuilder()
+                .setCurrencyCode("USD")
+                .setTotalPrice("12.24")
+                .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
+                .build();
+
+        request.transactionInfo(info)
+                .shippingAddressRequired(true)
+                .shippingAddressRequirements(nullyShippingAddressRequirements);
+
+        String actual = request.toJson();
+
+        JSONAssert.assertEquals(expected, actual, false);
+    }
 }


### PR DESCRIPTION
* When shippingAddressRequired() was true, all sub paramsi erroneously also became
required
* Allow users to require shipping address without requiring country
codes or phone number

# TODO
* [x] look for other instances where similar bugs may occur

@braintree/team-dx