### PR TITLE
Google Payment PayPal Client ID

### DIFF
--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -28,16 +28,18 @@ android {
     }
 }
 
+def braintreeVersion = '3.0.1-SNAPSHOT'
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.android.gms:play-services-wallet:16.0.1'
 
-    compileOnly('com.braintreepayments.api:braintree:3.0.0') {
+    compileOnly("com.braintreepayments.api:braintree:$braintreeVersion") {
         exclude module: 'google-payment'
         because 'Use this development version'
     }
 
-    testImplementation('com.braintreepayments.api:braintree:3.0.0') {
+    testImplementation("com.braintreepayments.api:braintree:$braintreeVersion") {
         exclude module: 'google-payment'
         because 'Use this development version'
     }

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -385,7 +385,7 @@ public class GooglePayment {
                     .put("purchase_units", new JSONArray()
                             .put(new JSONObject()
                                     .put("payee", new JSONObject()
-                                            .put("client_id", fragment.getConfiguration().getPayPal().getClientId())
+                                            .put("client_id", fragment.getConfiguration().getGooglePayment().getPaypalClientId())
                                     )
                                     .put("recurring_payment", "true")
                             )
@@ -455,7 +455,7 @@ public class GooglePayment {
                             .put("braintree:merchantId",
                                     fragment.getConfiguration().getMerchantId())
                             .put("braintree:paypalClientId",
-                                    fragment.getConfiguration().getPayPal().getClientId())
+                                    fragment.getConfiguration().getGooglePayment().getPaypalClientId())
                             .put("braintree:metadata", (new JSONObject()
                                     .put("source", "client")
                                     .put("integration", fragment.getIntegrationType())
@@ -507,8 +507,7 @@ public class GooglePayment {
         }
 
         boolean googlePaymentCanProcessPayPal = request.isPayPalEnabled() &&
-                configuration.isPayPalEnabled() &&
-                !TextUtils.isEmpty(configuration.getPayPal().getClientId());
+                !TextUtils.isEmpty(configuration.getGooglePayment().getPaypalClientId());
 
         if (googlePaymentCanProcessPayPal) {
             if (request.getAllowedPaymentMethod("PAYPAL") == null) {

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -31,6 +31,7 @@ import static com.braintreepayments.api.GooglePaymentActivity.EXTRA_ENVIRONMENT;
 import static com.braintreepayments.api.GooglePaymentActivity.EXTRA_PAYMENT_DATA_REQUEST;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -245,6 +246,8 @@ public class GooglePaymentUnitTest {
         assertEquals(1, allowedPaymentMethods.length());
         assertEquals("CARD", allowedPaymentMethods.getJSONObject(0)
                 .getString("type"));
+
+        assertFalse(allowedPaymentMethods.toString().contains("paypal-client-id-for-google-payment"));
     }
 
     @Test

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -135,7 +135,6 @@ public class GooglePaymentUnitTest {
         JSONArray allowedPaymentMethods = getPaymentDataRequestJsonSentToGooglePayment(fragment)
                 .getJSONArray("allowedPaymentMethods");
 
-
         assertEquals(2, allowedPaymentMethods.length());
         assertEquals("PAYPAL", allowedPaymentMethods.getJSONObject(0)
                 .getString("type"));
@@ -161,11 +160,12 @@ public class GooglePaymentUnitTest {
     }
 
     @Test
-    public void requestPayment_whenPayPalDisabledInConfiguration_tokenizationPropertiesLackPayPal() throws JSONException {
+    public void requestPayment_whenPayPalDisabledInConfigurationAndGooglePayHasPayPalClientId_tokenizationPropertiesContainPayPal() throws JSONException {
         TestConfigurationBuilder configuration = new TestConfigurationBuilder()
                 .googlePayment(new TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder()
                         .environment("sandbox")
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
+                        .paypalClientId("paypal-client-id-for-google-payment")
                         .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
                 .paypalEnabled(false)
                 .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(false))
@@ -180,19 +180,57 @@ public class GooglePaymentUnitTest {
         JSONArray allowedPaymentMethods = getPaymentDataRequestJsonSentToGooglePayment(fragment)
                 .getJSONArray("allowedPaymentMethods");
 
-        assertEquals(1, allowedPaymentMethods.length());
-        assertEquals("CARD", allowedPaymentMethods.getJSONObject(0)
+        assertEquals(2, allowedPaymentMethods.length());
+        assertEquals("PAYPAL", allowedPaymentMethods.getJSONObject(0)
+                .getString("type"));
+        assertEquals("CARD", allowedPaymentMethods.getJSONObject(1)
                 .getString("type"));
     }
 
     @Test
-    public void requestPayment_whenPayPalConfigurationLacksClientId_tokenizationPropertiesLackPayPal() throws JSONException {
+    public void requestPayment_usesGooglePaymentConfigurationClientId() throws JSONException {
+         TestConfigurationBuilder configuration = new TestConfigurationBuilder()
+                .googlePayment(new TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder()
+                        .environment("sandbox")
+                        .googleAuthorizationFingerprint("google-auth-fingerprint")
+                        .paypalClientId("paypal-client-id-for-google-payment")
+                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
+                 .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true)
+                         .clientId("paypal-client-id-for-paypal"))
+                .withAnalytics();
+
+        BraintreeFragment fragment = getSetupFragment(configuration);
+        GooglePaymentRequest googlePaymentRequest = mBaseRequest
+                .googleMerchantName("google-merchant-name-override");
+
+        GooglePayment.requestPayment(fragment, googlePaymentRequest);
+
+        JSONArray allowedPaymentMethods = getPaymentDataRequestJsonSentToGooglePayment(fragment)
+                .getJSONArray("allowedPaymentMethods");
+
+        JSONObject paypal = allowedPaymentMethods.getJSONObject(0);
+
+        assertEquals("paypal-client-id-for-google-payment",
+                paypal.getJSONObject("parameters")
+                        .getJSONObject("purchase_context")
+                        .getJSONArray("purchase_units")
+                        .getJSONObject(0)
+                        .getJSONObject("payee")
+                        .getString("client_id"));
+
+        assertEquals("paypal-client-id-for-google-payment",
+                paypal.getJSONObject("tokenizationSpecification")
+                        .getJSONObject("parameters")
+                        .getString("braintree:paypalClientId"));
+    }
+
+    @Test
+    public void requestPayment_whenGooglePaymentConfigurationLacksClientId_tokenizationPropertiesLackPayPal() throws JSONException {
         TestConfigurationBuilder configuration = new TestConfigurationBuilder()
                 .googlePayment(new TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder()
                         .environment("sandbox")
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
                         .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
-                .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true))
                 .withAnalytics();
 
         BraintreeFragment fragment = getSetupFragment(configuration);
@@ -247,9 +285,8 @@ public class GooglePaymentUnitTest {
                 .googlePayment(new TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder()
                         .environment(environment)
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
+                        .paypalClientId("paypal-client-id-for-google-payment")
                         .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
-                .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true)
-                        .clientId("paypal-client-id"))
                 .withAnalytics()
                 .build();
 

--- a/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
@@ -111,6 +111,11 @@ public class TestConfigurationBuilder extends JSONBuilder {
             put(new JSONArray(Arrays.asList(supportedNetworks)));
             return this;
         }
+
+        public TestGooglePaymentConfigurationBuilder paypalClientId(String paypalClientId) {
+            put(paypalClientId);
+            return this;
+        }
     }
 
     public static class TestPayPalConfigurationBuilder extends JSONBuilder {


### PR DESCRIPTION
Uses GooglePayment's PayPal Client ID instead of PayPal's Client ID.

NOTE: This is using a snapshot version of braintree-android that needs to be released, and switching to that released braintree-android version before merging this.