### PR TITLE
Add countryCode to support 3DS 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Bump `compileSdkVersion` and `targetSdkVersion` to API level 30
-* Add `setCountryCode()` to `GooglePaymentRequest`
+* Add `setCountryCode` to `GooglePaymentRequest`
 * Breaking Changes
   * Bump `minSdkVersion` to 21.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Bump `compileSdkVersion` and `targetSdkVersion` to API level 30
+* Add `setCountryCode()` to `GooglePaymentRequest`
 * Breaking Changes
   * Bump `minSdkVersion` to 21.
 

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/GooglePaymentRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/GooglePaymentRequest.java
@@ -40,6 +40,7 @@ public class GooglePaymentRequest implements Parcelable {
     private String mEnvironment;
     private String mGoogleMerchantId;
     private String mGoogleMerchantName;
+    private String mCountryCode;
 
     public GooglePaymentRequest() {
     }
@@ -214,6 +215,17 @@ public class GooglePaymentRequest implements Parcelable {
     }
 
     /**
+     * ISO 3166-1 alpha-2 country code where the transaction is processed. This is required for
+     * merchants based in European Economic Area (EEA) countries.
+     * @param countryCode
+     * @return {@link GooglePaymentRequest}
+     */
+    public GooglePaymentRequest setCountryCode(String countryCode) {
+        mCountryCode = countryCode;
+        return this;
+    }
+
+    /**
      * Assemble all declared parts of a GooglePaymentRequest to a JSON string
      * for use in making requests against Google
      * @return String
@@ -245,6 +257,10 @@ public class GooglePaymentRequest implements Parcelable {
                     .put("totalPriceStatus", totalPriceStatus)
                     .put("totalPrice", transactionInfo.getTotalPrice())
                     .put("currencyCode", transactionInfo.getCurrencyCode());
+
+            if (mCountryCode != null) {
+                transactionInfoJson.put("countryCode", mCountryCode);
+            }
 
         } catch (JSONException ignored) {
         }

--- a/GooglePayment/src/test/assets/fixtures/payment_methods/google_payment_request.json
+++ b/GooglePayment/src/test/assets/fixtures/payment_methods/google_payment_request.json
@@ -70,6 +70,7 @@
   "transactionInfo": {
     "totalPriceStatus": "FINAL",
     "totalPrice": "12.24",
-    "currencyCode": "USD"
+    "currencyCode": "USD",
+    "countryCode": "US"
   }
 }

--- a/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/models/GooglePaymentRequestUnitTest.java
@@ -207,6 +207,7 @@ public class GooglePaymentRequestUnitTest {
                 .put("purchase_context", "{\"purchase_context\":{\"purchase_units\":[{\"payee\":{\"client_id\":\"FAKE_PAYPAL_CLIENT_ID\"},\"recurring_payment\":false}]}}");
 
         request.transactionInfo(info)
+                .setCountryCode("US")
                 .phoneNumberRequired(true)
                 .emailRequired(true)
                 .shippingAddressRequired(true)


### PR DESCRIPTION
This looks to add a missing field required for SCA/3DS 2 to Google Pay as dictated [here in the Google Docs](https://developers.google.com/pay/api/web/guides/resources/sca)