### PR TITLE
Add check in `requestPayment` to avoid NPE

### DIFF
--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
     testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
-    testImplementation 'org.robolectric:robolectric:4.0-alpha-3'
+    testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
 }

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -198,6 +198,12 @@ public class GooglePayment {
             @Override
             public void onConfigurationFetched(Configuration configuration) {
 
+                if (!configuration.getGooglePayment().isEnabled(fragment.getApplicationContext())) {
+                    fragment.postCallback(new BraintreeException("This merchant does not have Google Pay enabled," +
+                            " or Google Play Services are not configured correctly."));
+                    return;
+                }
+
                 setGooglePaymentRequestDefaults(fragment, configuration, request);
 
                 fragment.sendAnalyticsEvent("google-payment.started");

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -82,9 +82,7 @@ public class GooglePaymentUnitTest {
 
     @Test
     public void requestPayment_whenMerchantNotConfigured_returnsExceptionToFragment() {
-        String configuration = new TestConfigurationBuilder()
-                .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true))
-                .build();
+        String configuration = new TestConfigurationBuilder().build();
 
         BraintreeFragment fragment = new MockFragmentBuilder()
                 .configuration(configuration)

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -1,9 +1,12 @@
 package com.braintreepayments.api;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 
 import com.braintreepayments.api.exceptions.BraintreeException;
 import com.braintreepayments.api.exceptions.InvalidArgumentException;
+import com.braintreepayments.api.internal.ManifestValidator;
 import com.braintreepayments.api.models.Authorization;
 import com.braintreepayments.api.models.BraintreeRequestCodes;
 import com.braintreepayments.api.models.GooglePaymentCardNonce;
@@ -12,6 +15,8 @@ import com.braintreepayments.api.models.PayPalAccountNonce;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 import com.braintreepayments.api.test.FixturesHelper;
 import com.braintreepayments.api.test.TestConfigurationBuilder;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.wallet.PaymentData;
 import com.google.android.gms.wallet.PaymentDataRequest;
 import com.google.android.gms.wallet.TransactionInfo;
@@ -21,9 +26,13 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 
 import androidx.annotation.NonNull;
@@ -33,12 +42,19 @@ import static com.braintreepayments.api.GooglePaymentActivity.EXTRA_PAYMENT_DATA
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(RobolectricTestRunner.class)
+@PrepareForTest({GoogleApiAvailability.class, ManifestValidator.class})
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
 public class GooglePaymentUnitTest {
+    @Rule
+    public PowerMockRule mPowerMockRule = new PowerMockRule();
 
     private GooglePaymentRequest mBaseRequest;
 
@@ -50,6 +66,18 @@ public class GooglePaymentUnitTest {
                     .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
                     .setCurrencyCode("USD")
                     .build());
+
+       GoogleApiAvailability mockGoogleApiAvailability = mock(GoogleApiAvailability.class);
+       when(mockGoogleApiAvailability.isGooglePlayServicesAvailable(any(Context.class))).thenReturn(ConnectionResult.SUCCESS);
+
+       mockStatic(GoogleApiAvailability.class);
+       when(GoogleApiAvailability.getInstance()).thenReturn(mockGoogleApiAvailability);
+
+       ActivityInfo mockActivityInfo = mock(ActivityInfo.class);
+       when(mockActivityInfo.getThemeResource()).thenReturn(2132083045);
+
+       mockStatic(ManifestValidator.class);
+       when(ManifestValidator.getActivityInfo(any(Context.class), any(Class.class))).thenReturn(mockActivityInfo);
     }
 
     @Test
@@ -187,7 +215,8 @@ public class GooglePaymentUnitTest {
                         .environment("sandbox")
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
                         .paypalClientId("paypal-client-id-for-google-payment")
-                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
+                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"})
+                        .enabled(true))
                 .paypalEnabled(false)
                 .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(false))
                 .withAnalytics();
@@ -215,7 +244,8 @@ public class GooglePaymentUnitTest {
                         .environment("sandbox")
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
                         .paypalClientId("paypal-client-id-for-google-payment")
-                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
+                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"})
+                        .enabled(true))
                  .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true)
                          .clientId("paypal-client-id-for-paypal"))
                 .withAnalytics();
@@ -251,7 +281,8 @@ public class GooglePaymentUnitTest {
                 .googlePayment(new TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder()
                         .environment("sandbox")
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
-                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
+                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"})
+                        .enabled(true))
                 .withAnalytics();
 
         BraintreeFragment fragment = getSetupFragment(configuration);
@@ -309,7 +340,8 @@ public class GooglePaymentUnitTest {
                         .environment(environment)
                         .googleAuthorizationFingerprint("google-auth-fingerprint")
                         .paypalClientId("paypal-client-id-for-google-payment")
-                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"}))
+                        .supportedNetworks(new String[]{"visa", "mastercard", "amex", "discover"})
+                        .enabled(true))
                 .withAnalytics()
                 .build();
 

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -2,6 +2,7 @@ package com.braintreepayments.api;
 
 import android.content.Intent;
 
+import com.braintreepayments.api.exceptions.BraintreeException;
 import com.braintreepayments.api.exceptions.InvalidArgumentException;
 import com.braintreepayments.api.models.Authorization;
 import com.braintreepayments.api.models.BraintreeRequestCodes;
@@ -49,6 +50,25 @@ public class GooglePaymentUnitTest {
                     .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
                     .setCurrencyCode("USD")
                     .build());
+    }
+
+    @Test
+    public void requestPayment_whenMerchantNotConfigured_returnsExceptionToFragment() {
+        String configuration = new TestConfigurationBuilder()
+                .paypal(new TestConfigurationBuilder.TestPayPalConfigurationBuilder(true))
+                .build();
+
+        BraintreeFragment fragment = new MockFragmentBuilder()
+                .configuration(configuration)
+                .build();
+
+        GooglePayment.requestPayment(fragment, mBaseRequest);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(fragment).postCallback(captor.capture());
+        assertTrue(captor.getValue() instanceof BraintreeException);
+        assertEquals("This merchant does not have Google Pay enabled, or Google Play Services are not configured correctly.",
+                captor.getValue().getMessage());
     }
 
     @Test

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -67,7 +67,7 @@ public class GooglePaymentUnitTest {
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(fragment).postCallback(captor.capture());
         assertTrue(captor.getValue() instanceof BraintreeException);
-        assertEquals("This merchant does not have Google Pay enabled, or Google Play Services are not configured correctly.",
+        assertEquals("Google Pay enabled is not enabled for your Braintree account, or Google Play Services are not configured correctly.",
                 captor.getValue().getMessage());
     }
 

--- a/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/test/TestConfigurationBuilder.java
@@ -116,6 +116,11 @@ public class TestConfigurationBuilder extends JSONBuilder {
             put(paypalClientId);
             return this;
         }
+
+        public TestGooglePaymentConfigurationBuilder enabled(boolean enabled) {
+            put(enabled);
+            return this;
+        }
     }
 
     public static class TestPayPalConfigurationBuilder extends JSONBuilder {


### PR DESCRIPTION
This fix will return an exception if `requestPayment` is called when
Google Pay is not enabled.  Ideally this would be caught in
`isReadyToPay`, however it's possible though not advised to jump
straight to calling `requestPayment` and get a Null Pointer Exception if
some values are not set in the configuration.