### PR TITLE
Bump core SDK version, Fix BuildConfig version reference

### DIFF
--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -28,7 +28,7 @@ android {
     }
 }
 
-def braintreeVersion = '3.0.1-SNAPSHOT'
+def braintreeVersion = '3.7.0'
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -3,7 +3,6 @@ package com.braintreepayments.api;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.os.Build;
 import android.text.TextUtils;
 
 import com.braintreepayments.api.exceptions.BraintreeException;

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -3,6 +3,7 @@ package com.braintreepayments.api;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.os.Build;
 import android.text.TextUtils;
 
 import com.braintreepayments.api.exceptions.BraintreeException;
@@ -408,18 +409,19 @@ public class GooglePayment {
     private static JSONObject buildCardTokenizationSpecification(BraintreeFragment fragment) {
         JSONObject cardJson = new JSONObject();
         JSONObject parameters = new JSONObject();
+        String googlePaymentVersion = com.braintreepayments.api.googlepayment.BuildConfig.VERSION_NAME;
 
         try {
             parameters
                     .put("gateway", "braintree")
                     .put("braintree:apiVersion", "v1")
-                    .put("braintree:sdkVersion", BuildConfig.VERSION_NAME)
+                    .put("braintree:sdkVersion", googlePaymentVersion)
                     .put("braintree:merchantId", fragment.getConfiguration().getMerchantId())
                     .put("braintree:metadata", (new JSONObject()
                             .put("source", "client")
                             .put("integration", fragment.getIntegrationType())
                             .put("sessionId", fragment.getSessionId())
-                            .put("version", BuildConfig.VERSION_NAME)
+                            .put("version", googlePaymentVersion)
                             .put("platform", "android")).toString());
 
             if (Authorization.isTokenizationKey(fragment.getAuthorization().toString())) {
@@ -451,13 +453,14 @@ public class GooglePayment {
 
     private static JSONObject buildPayPalTokenizationSpecification(BraintreeFragment fragment) {
         JSONObject json = new JSONObject();
+        String googlePaymentVersion = com.braintreepayments.api.googlepayment.BuildConfig.VERSION_NAME;
 
         try {
             json.put("type", "PAYMENT_GATEWAY")
                     .put("parameters", new JSONObject()
                             .put("gateway", "braintree")
                             .put("braintree:apiVersion", "v1")
-                            .put("braintree:sdkVersion", BuildConfig.VERSION_NAME)
+                            .put("braintree:sdkVersion", googlePaymentVersion)
                             .put("braintree:merchantId",
                                     fragment.getConfiguration().getMerchantId())
                             .put("braintree:paypalClientId",
@@ -466,7 +469,7 @@ public class GooglePayment {
                                     .put("source", "client")
                                     .put("integration", fragment.getIntegrationType())
                                     .put("sessionId", fragment.getSessionId())
-                                    .put("version", BuildConfig.VERSION_NAME)
+                                    .put("version", googlePaymentVersion)
                                     .put("platform", "android")).toString()));
         } catch (JSONException ignored) {
         }


### PR DESCRIPTION
This bumps the core SDK dependency version to the current version to
include 3DSecure, in the event it's required.

It also fixes an issue where the wrong SDK version was being passed to
various fields.  This was coincidentally correct as the base SDK version
matched the version of the google pay module.  When the no longer
matched, the bug presented itself.