### PR TITLE
Add Support for GooglePay's existingPaymentMethodRequired Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree Android Google Pay SDK Release Notes
 
+## unreleased
+* Add support for GooglePay "Existing Payment Method" configuration
+
 ## 3.2.0
 * Add support for `isNetworkTokenized`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree Android Google Pay SDK Release Notes
 
 ## unreleased
-* Add support for GooglePay "Existing Payment Method" configuration
+* Add support for Google Pay's `existingPaymentMethodRequired` option
 
 ## 3.2.0
 * Add support for `isNetworkTokenized`

--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     }
 
     testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
-    testImplementation 'androidx.test:runner:1.1.1'
-    testImplementation 'androidx.test:rules:1.1.1'
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -83,7 +83,6 @@ public class GooglePayment {
 
     /**
      * Before starting the Google Payments flow, use this method to check whether the
-     * {@link #isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)} to check whether the
      * Google Payment API is supported and set up on the device. When the listener is called with
      * {@code true}, show the Google Payments button. When it is called with {@code false}, display other
      * checkout options.

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -5,6 +5,10 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.braintreepayments.api.exceptions.BraintreeException;
 import com.braintreepayments.api.exceptions.ErrorWithResponse;
 import com.braintreepayments.api.exceptions.GoogleApiClientException;
@@ -23,7 +27,7 @@ import com.braintreepayments.api.models.GooglePaymentConfiguration;
 import com.braintreepayments.api.models.GooglePaymentRequest;
 import com.braintreepayments.api.models.MetadataBuilder;
 import com.braintreepayments.api.models.PaymentMethodNonceFactory;
-import com.braintreepayments.api.models.ReadyForGooglePayRequest;
+import com.braintreepayments.api.models.ReadyForGooglePaymentRequest;
 import com.braintreepayments.api.models.TokenizationKey;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -44,9 +48,6 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import static com.braintreepayments.api.GooglePaymentActivity.EXTRA_ENVIRONMENT;
 import static com.braintreepayments.api.GooglePaymentActivity.EXTRA_PAYMENT_DATA_REQUEST;
@@ -88,12 +89,12 @@ public class GooglePayment {
      * checkout options.
      *
      * @param fragment {@link BraintreeFragment}
-     * @param request {@link ReadyForGooglePayRequest}
+     * @param request {@link ReadyForGooglePaymentRequest}
      * @param listener Instance of {@link BraintreeResponseListener<Boolean>} to receive the
      *                 isReadyToPay response.
      */
     public static void isReadyToPay(final BraintreeFragment fragment,
-                                    final ReadyForGooglePayRequest request,
+                                    final @Nullable ReadyForGooglePaymentRequest request,
                                     final BraintreeResponseListener<Boolean> listener) {
         try {
             Class.forName(PaymentsClient.class.getName());

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -82,7 +82,7 @@ public class GooglePayment {
     }
 
     /**
-     * Before starting the Google Payments flow, use
+     * Before starting the Google Payments flow, use this method to check whether the
      * {@link #isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)} to check whether the
      * Google Payment API is supported and set up on the device. When the listener is called with
      * {@code true}, show the Google Payments button. When it is called with {@code false}, display other

--- a/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/GooglePayment.java
@@ -23,6 +23,7 @@ import com.braintreepayments.api.models.GooglePaymentConfiguration;
 import com.braintreepayments.api.models.GooglePaymentRequest;
 import com.braintreepayments.api.models.MetadataBuilder;
 import com.braintreepayments.api.models.PaymentMethodNonceFactory;
+import com.braintreepayments.api.models.ReadyForGooglePayRequest;
 import com.braintreepayments.api.models.TokenizationKey;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -77,6 +78,24 @@ public class GooglePayment {
      */
     public static void isReadyToPay(final BraintreeFragment fragment,
                                     final BraintreeResponseListener<Boolean> listener) {
+        isReadyToPay(fragment, null, listener);
+    }
+
+    /**
+     * Before starting the Google Payments flow, use
+     * {@link #isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)} to check whether the
+     * Google Payment API is supported and set up on the device. When the listener is called with
+     * {@code true}, show the Google Payments button. When it is called with {@code false}, display other
+     * checkout options.
+     *
+     * @param fragment {@link BraintreeFragment}
+     * @param request {@link ReadyForGooglePayRequest}
+     * @param listener Instance of {@link BraintreeResponseListener<Boolean>} to receive the
+     *                 isReadyToPay response.
+     */
+    public static void isReadyToPay(final BraintreeFragment fragment,
+                                    final ReadyForGooglePayRequest request,
+                                    final BraintreeResponseListener<Boolean> listener) {
         try {
             Class.forName(PaymentsClient.class.getName());
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
@@ -101,7 +120,6 @@ public class GooglePayment {
                                 .setEnvironment(getEnvironment(configuration.getGooglePayment()))
                                 .build());
 
-
                 JSONObject json = new JSONObject();
                 JSONArray allowedCardNetworks = new JSONArray();
 
@@ -121,6 +139,11 @@ public class GooglePayment {
                                                             .put("PAN_ONLY")
                                                             .put("CRYPTOGRAM_3DS"))
                                                     .put("allowedCardNetworks", allowedCardNetworks))));
+
+                    if (request != null) {
+                        json.put("existingPaymentMethodRequired", request.isExistingPaymentMethodRequired());
+                    }
+
                 } catch (JSONException ignored) {
                 }
 

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
@@ -14,7 +14,7 @@ public class ReadyForGooglePayRequest {
     /**
      * If set to true, then the {@link GooglePayment#isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)}
      * method will call the listener with true if the customer is ready to pay with one or more of your
-     * allowed card networks.
+     * supported card networks.
      *
      * @param value Indicates whether the customer must have one or more payment methods from your allowed card networks in order
      *              to be considered ready to pay with Google Pay

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
@@ -16,7 +16,7 @@ public class ReadyForGooglePayRequest {
      * method will call the listener with true if the customer is ready to pay with one or more of your
      * supported card networks.
      *
-     * @param value Indicates whether the customer must have one or more payment methods from your allowed card networks in order
+     * @param value Indicates whether the customer must have one or more payment methods from your supported card networks in order
      *              to be considered ready to pay with Google Pay
      *
      * @return {@link ReadyForGooglePayRequest}

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
@@ -1,0 +1,15 @@
+package com.braintreepayments.api.models;
+
+public class ReadyForGooglePayRequest {
+
+    private boolean mExistingPaymentMethodRequired;
+
+    public ReadyForGooglePayRequest existingPaymentMethodRequired(boolean value) {
+        mExistingPaymentMethodRequired = value;
+        return this;
+    }
+
+    public boolean isExistingPaymentMethodRequired() {
+        return mExistingPaymentMethodRequired;
+    }
+}

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePayRequest.java
@@ -1,9 +1,26 @@
 package com.braintreepayments.api.models;
 
+import com.braintreepayments.api.BraintreeFragment;
+import com.braintreepayments.api.GooglePayment;
+import com.braintreepayments.api.interfaces.BraintreeResponseListener;
+
+/**
+ * Optional parameters to use when checking whether Google Payment API is supported and set up on the device.
+ */
 public class ReadyForGooglePayRequest {
 
     private boolean mExistingPaymentMethodRequired;
 
+    /**
+     * If set to true, then the {@link GooglePayment#isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)}
+     * method will call the listener with true if the customer is ready to pay with one or more of your
+     * allowed card networks.
+     *
+     * @param value Indicates whether the customer must have one or more payment methods from your allowed card networks in order
+     *              to be considered ready to pay with Google Pay
+     *
+     * @return {@link ReadyForGooglePayRequest}
+     */
     public ReadyForGooglePayRequest existingPaymentMethodRequired(boolean value) {
         mExistingPaymentMethodRequired = value;
         return this;

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePaymentRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePaymentRequest.java
@@ -5,7 +5,7 @@ import com.braintreepayments.api.GooglePayment;
 import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 
 /**
- * Optional parameters to use when checking whether Google Payment API is supported and set up on the device.
+ * Optional parameters to use when checking whether Google Pay is supported and set up on the customer's device.
  */
 public class ReadyForGooglePaymentRequest {
 

--- a/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePaymentRequest.java
+++ b/GooglePayment/src/main/java/com/braintreepayments/api/models/ReadyForGooglePaymentRequest.java
@@ -7,22 +7,22 @@ import com.braintreepayments.api.interfaces.BraintreeResponseListener;
 /**
  * Optional parameters to use when checking whether Google Payment API is supported and set up on the device.
  */
-public class ReadyForGooglePayRequest {
+public class ReadyForGooglePaymentRequest {
 
     private boolean mExistingPaymentMethodRequired;
 
     /**
-     * If set to true, then the {@link GooglePayment#isReadyToPay(BraintreeFragment, ReadyForGooglePayRequest, BraintreeResponseListener)}
+     * If set to true, then the {@link GooglePayment#isReadyToPay(BraintreeFragment, ReadyForGooglePaymentRequest, BraintreeResponseListener)}
      * method will call the listener with true if the customer is ready to pay with one or more of your
      * supported card networks.
      *
-     * @param value Indicates whether the customer must have one or more payment methods from your supported card networks in order
-     *              to be considered ready to pay with Google Pay
+     * @param existingPaymentMethodRequired Indicates whether the customer must already have at least one payment method from your supported
+     *              card networks in order to be considered ready to pay with Google Pay
      *
-     * @return {@link ReadyForGooglePayRequest}
+     * @return {@link ReadyForGooglePaymentRequest}
      */
-    public ReadyForGooglePayRequest existingPaymentMethodRequired(boolean value) {
-        mExistingPaymentMethodRequired = value;
+    public ReadyForGooglePaymentRequest existingPaymentMethodRequired(boolean existingPaymentMethodRequired) {
+        mExistingPaymentMethodRequired = existingPaymentMethodRequired;
         return this;
     }
 

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -17,7 +17,7 @@ import com.braintreepayments.api.models.GooglePaymentCardNonce;
 import com.braintreepayments.api.models.GooglePaymentRequest;
 import com.braintreepayments.api.models.PayPalAccountNonce;
 import com.braintreepayments.api.models.PaymentMethodNonce;
-import com.braintreepayments.api.models.ReadyForGooglePayRequest;
+import com.braintreepayments.api.models.ReadyForGooglePaymentRequest;
 import com.braintreepayments.api.test.FixturesHelper;
 import com.braintreepayments.api.test.TestConfigurationBuilder;
 import com.braintreepayments.api.test.TestConfigurationBuilder.TestGooglePaymentConfigurationBuilder;
@@ -150,8 +150,8 @@ public class GooglePaymentUnitTest {
         mockStatic(Wallet.class);
         when(Wallet.getPaymentsClient(any(Activity.class), any(Wallet.WalletOptions.class))).thenReturn(mockPaymentsClient);
 
-        ReadyForGooglePayRequest readyForGooglePayRequest = new ReadyForGooglePayRequest().existingPaymentMethodRequired(true);
-        GooglePayment.isReadyToPay(mMockFragment, readyForGooglePayRequest, new BraintreeResponseListener<Boolean>() {
+        ReadyForGooglePaymentRequest readyForGooglePaymentRequest = new ReadyForGooglePaymentRequest().existingPaymentMethodRequired(true);
+        GooglePayment.isReadyToPay(mMockFragment, readyForGooglePaymentRequest, new BraintreeResponseListener<Boolean>() {
             @Override
             public void onResponse(Boolean aBoolean) {
                 // do nothing

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -54,10 +54,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @PrepareForTest({GoogleApiAvailability.class, ManifestValidator.class, Wallet.class})


### PR DESCRIPTION
## Add Support for GooglePay "Existing Payment Method"

### Summary of changes

 - Add support for GooglePay's [existingPaymentMethodRequired](https://developers.google.com/pay/api/android/reference/request-objects) field

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens @sshropshire 