### PR TITLE
Remove references to sdk-announce google-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ Here are a few ways to get in touch:
 * [Braintree Support](https://articles.braintreepayments.com/) / [support@braintreepayments.com](mailto:support@braintreepayments.com) -
 for personal support at any phase of integration
 
-## Releases
-
-Subscribe to our [Google Group](https://groups.google.com/forum/#!forum/braintree-sdk-announce) to
-be notified when SDK releases go out.
-
 ## License
 
 Braintree Android Google Payment is open source and available under the MIT license. See the [LICENSE](LICENSE) file for more info.

--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,6 @@ task :assumptions do
     puts "* [ ] You have already merged hotfixes and pulled changes."
     puts "* [ ] You have already reviewed the diff between the current release and the last tag, noting breaking changes in the semver and CHANGELOG."
     puts "* [ ] Tests (rake integration_tests) are passing, manual verifications complete."
-    puts "* [ ] Email is composed and ready to send to braintree-sdk-announce@googlegroups.com"
 
     puts "Ready to release? Press any key to continue. "
     $stdin.gets


### PR DESCRIPTION
### Summary of changes

 - Remove references to sdk-announce google-group

 ### Checklist

 - [ ] Added a changelog entry
