### PR TITLE
Gradle Standardization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-28.0.3
+    - build-tools-29.0.3
     - android-28
     - extra-google-m2repository
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree Android Google Pay SDK Release Notes
 
+## unreleased
+* Breaking Changes
+  * Bump `minSdkVersion` to 21.
+
 ## 3.3.1
 * Fix `allowedCardNetworks` in `isReadyToPayRequest` to be uppercased. Thanks @fcastagnozzi.
 

--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -44,16 +44,16 @@ dependencies {
         because 'Use this development version'
     }
 
-    testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
-    testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
     testImplementation 'org.powermock:powermock-classloading-xstream:1.6.6'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
+    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'org.skyscreamer:jsonassert:1.4.0'
-    testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
 }
 
 // region signing and publishing

--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -1,16 +1,18 @@
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
-apply plugin: 'signing'
+plugins {
+    id 'com.android.library'
+    id 'de.marcphilipp.nexus-publish'
+    id 'signing'
+}
 
 android {
-    buildToolsVersion '28.0.3'
-    compileSdkVersion 28
+    compileSdkVersion rootProject.compileSdkVersion
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
-        versionCode = rootProject.ext.versionCode
-        versionName = rootProject.ext.versionName
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+        versionCode rootProject.versionCode
+        versionName rootProject.versionName
 
         consumerProguardFiles 'proguard.pro'
     }
@@ -28,18 +30,16 @@ android {
     }
 }
 
-def braintreeVersion = '3.7.0'
-
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'com.google.android.gms:play-services-wallet:16.0.1'
 
-    compileOnly("com.braintreepayments.api:braintree:$braintreeVersion") {
+    compileOnly("com.braintreepayments.api:braintree:$rootProject.braintreeVersion") {
         exclude module: 'google-payment'
         because 'Use this development version'
     }
 
-    testImplementation("com.braintreepayments.api:braintree:$braintreeVersion") {
+    testImplementation("com.braintreepayments.api:braintree:$rootProject.braintreeVersion") {
         exclude module: 'google-payment'
         because 'Use this development version'
     }
@@ -56,7 +56,8 @@ dependencies {
     testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
 }
 
-/* maven deploy + signing */
+// region signing and publishing
+
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
@@ -64,12 +65,12 @@ task javadocs(type: Javadoc) {
 }
 
 task javadocsJar(type: Jar, dependsOn: javadocs) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadocs.destinationDir
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
 }
 
@@ -80,74 +81,59 @@ artifacts {
 
 signing {
     required {
-        !android.defaultConfig.versionName.endsWith("SNAPSHOT") &&
-        !android.defaultConfig.versionName.endsWith("DEVELOPMENT")
+        !version.endsWith("SNAPSHOT") && !version.endsWith("DEVELOPMENT")
     }
-    sign configurations.archives
+    sign publishing.publications
 }
 
-def sonatypeUsername = System.env['SONATYPE_USERNAME']
-def sonatypePassword = System.env['SONATYPE_PASSWORD']
-
-nexusStaging {
-    packageGroup = "com.braintreepayments"
-    delayBetweenRetriesInMillis = 10000
-    username = sonatypeUsername
-    password = sonatypePassword
-}
-
-uploadArchives {
+nexusPublishing {
+    // give nexus sonatype more time to initialize the staging repository
+    clientTimeout = Duration.ofMinutes(3)
     repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+        sonatype()
+    }
+}
 
-            if (android.defaultConfig.versionName.endsWith('DEVELOPMENT')) {
-                repository(url: 'file:///tmp/maven/')
-            } else {
-                repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                    authentication(userName: sonatypeUsername, password: sonatypePassword)
-                }
-            }
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
 
-            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                authentication(userName: sonatypeUsername, password: sonatypePassword)
-            }
-
-            pom.setArtifactId 'google-payment'
-
-            pom.project {
-                name 'google-payment'
                 groupId = 'com.braintreepayments.api'
-                version = "${android.defaultConfig.versionName}"
-                packaging 'jar'
-                description 'Google Pay Module for Braintree\'s Android SDK.'
-                url 'https://github.com/braintree/braintree-android-google-payment'
+                artifactId = 'google-payment'
+                version = rootProject.versionName
 
-                scm {
-                    url 'scm:git@github.com:braintree/braintree-android-google-payment.git'
-                    connection 'scm:git@github.com:braintree/braintree-android-google-payment.git'
-                    developerConnection 'scm:git@github.com:braintree/braintree-android-google-payment.git'
-                }
+                pom {
+                    name = 'google-payment'
+                    packaging = 'jar'
+                    description = 'Google Pay Module for Braintree\'s Android SDK.'
+                    url = 'https://github.com/braintree/braintree-android-google-payment'
 
-                developers {
-                    developer {
-                        id 'devs'
-                        name 'Braintree Payments'
+                    scm {
+                        url = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
+                        connection = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
+                        developerConnection = 'scm:git@github.com:braintree/braintree-android-google-payment.git'
+                    }
+
+                    developers {
+                        developer {
+                            id = 'devs'
+                            name = 'Braintree Payments'
+                        }
+                    }
+
+                    licenses {
+                        license {
+                            name = 'MIT'
+                            url = 'http://opensource.org/licenses/MIT'
+                            distribution = 'repo'
+                        }
                     }
                 }
-
-                licenses {
-                    license {
-                        name 'MIT'
-                        url 'http://opensource.org/licenses/MIT'
-                        distribution 'repo'
-                    }
-                }
-            }
-
-            pom.whenConfigured {
-                it.dependencies.removeAll { true }
             }
         }
     }
 }
+
+// endregion

--- a/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
+++ b/GooglePayment/src/test/java/com/braintreepayments/api/GooglePaymentUnitTest.java
@@ -94,7 +94,7 @@ public class GooglePaymentUnitTest {
         when(GoogleApiAvailability.getInstance()).thenReturn(mockGoogleApiAvailability);
 
         ActivityInfo mockActivityInfo = mock(ActivityInfo.class);
-        when(mockActivityInfo.getThemeResource()).thenReturn(2132083045);
+        when(mockActivityInfo.getThemeResource()).thenReturn(R.style.bt_transparent_activity);
 
         mockStatic(ManifestValidator.class);
         when(ManifestValidator.getActivityInfo(any(Context.class), any(Class.class))).thenReturn(mockActivityInfo);

--- a/Rakefile
+++ b/Rakefile
@@ -121,7 +121,7 @@ end
 def update_version(version)
   IO.write("build.gradle",
     File.open("build.gradle") do |file|
-      file.read.gsub(/^version = '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version = '#{version}'")
+      file.read.gsub(/^version '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version = '#{version}'")
     end
   )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,7 @@ end
 def get_current_version
   current_version = nil
   File.foreach("build.gradle") do |line|
-    if match = line.match(/version = '(\d+\.\d+\.\d+(-SNAPSHOT)?)'/)
+    if match = line.match(/^version '(\d+\.\d+\.\d+(-SNAPSHOT)?)'/)
       current_version = match.captures
     end
   end
@@ -121,7 +121,7 @@ end
 def update_version(version)
   IO.write("build.gradle",
     File.open("build.gradle") do |file|
-      file.read.gsub(/^version '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version = '#{version}'")
+      file.read.gsub(/^version '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version '#{version}'")
     end
   )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -121,7 +121,7 @@ end
 def update_version(version)
   IO.write("build.gradle",
     File.open("build.gradle") do |file|
-      file.read.gsub(/version = '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version = '#{version}'")
+      file.read.gsub(/^version = '\d+\.\d+\.\d+(-SNAPSHOT)?'/, "version = '#{version}'")
     end
   )
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,18 +13,6 @@ task :unit_tests => :lint do
   sh "./gradlew --continue test"
 end
 
-desc "Publish current version as a SNAPSHOT"
-task :publish_snapshot => :unit_tests do
-  abort("Version must contain '-SNAPSHOT'!") unless get_current_version.end_with?('-SNAPSHOT')
-
-  puts "Ensure all tests are passing (`rake`)."
-  $stdin.gets
-
-  prompt_for_sonatype_username_and_password
-
-  sh "./gradlew clean :GooglePayment:uploadArchives"
-end
-
 desc "Interactive release to publish new version"
 task :release => :unit_tests do
   Rake::Task["assumptions"].invoke
@@ -48,18 +36,14 @@ task :assumptions do
     puts "* [ ] You have already merged hotfixes and pulled changes."
     puts "* [ ] You have already reviewed the diff between the current release and the last tag, noting breaking changes in the semver and CHANGELOG."
     puts "* [ ] Tests (rake integration_tests) are passing, manual verifications complete."
-    puts "* [ ] Email is composed and ready to send to braintree-sdk-announce@googlegroups.com"
 
     puts "Ready to release? Press any key to continue. "
     $stdin.gets
 end
 
 task :release_braintree_google_payment do
-  sh "./gradlew clean :GooglePayment:uploadArchives"
+  sh "./gradlew clean :GooglePayment:publishToSonatype"
   sh "./gradlew closeAndReleaseRepository"
-  puts "Sleeping for 600 seconds"
-  sleep 600
-  puts "Braintree google pay module have been released"
 end
 
 def prompt_for_sonatype_username_and_password

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,6 @@ plugins {
     id 'io.codearte.nexus-staging' version '0.21.2'
 }
 
-allprojects {
-    repositories {
-        jcenter()
-        google()
-    }
-}
-
 version = '3.3.2-SNAPSHOT'
 ext {
     compileSdkVersion = 28
@@ -32,6 +25,13 @@ ext {
     versionCode = 11
     versionName = version
     braintreeVersion = '3.7.0'
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        google()
+    }
 }
 
 nexusStaging {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     }
 }
 
-version '3.3.2-SNAPSHOT'
+version = '3.3.2-SNAPSHOT'
 ext {
     compileSdkVersion = 28
     minSdkVersion = 16

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 version = '3.3.2-SNAPSHOT'
 ext {
     compileSdkVersion = 28
-    minSdkVersion = 16
+    minSdkVersion = 21
     targetSdkVersion = 28
     versionCode = 11
     versionName = version

--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,43 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
+        maven {
+            url = "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }
+}
+
+plugins {
+    id 'io.codearte.nexus-staging' version '0.21.2'
 }
 
 allprojects {
     repositories {
         jcenter()
         google()
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/releases/'
-        }
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        maven {
-            url 'file:///tmp/maven/'
-        }
     }
 }
 
-version = '3.3.2-SNAPSHOT'
+version '3.3.2-SNAPSHOT'
 ext {
-  versionCode = 11
-  versionName = version
+    compileSdkVersion = 28
+    minSdkVersion = 16
+    targetSdkVersion = 28
+    versionCode = 11
+    versionName = version
+    braintreeVersion = '3.7.0'
 }
 
-apply plugin: 'io.codearte.nexus-staging'
+nexusStaging {
+    packageGroup = "com.braintreepayments"
+    // give nexus sonatype more time to close the staging repository
+    delayBetweenRetriesInMillis = 20000
+    username = System.env['SONATYPE_USERNAME']
+    password = System.env['SONATYPE_PASSWORD']
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/script/deploy_snapshot.sh
+++ b/script/deploy_snapshot.sh
@@ -14,7 +14,7 @@ elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo "Skipping snapshot deployment: was pull request."
 elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
-elif [[ $(./gradlew properties | grep version) != *-SNAPSHOT ]]; then
+elif [[ $(./gradlew properties | grep versionName) != *-SNAPSHOT ]]; then
   echo "Skipping snapshot deployment: not a snapshot version."
 else
   echo "Deploying snapshot..."

--- a/script/deploy_snapshot.sh
+++ b/script/deploy_snapshot.sh
@@ -18,6 +18,6 @@ elif [[ $(./gradlew properties | grep version) != *-SNAPSHOT ]]; then
   echo "Skipping snapshot deployment: not a snapshot version."
 else
   echo "Deploying snapshot..."
-  ./gradlew :GooglePayment:uploadArchives
+  ./gradlew :GooglePayment:publishToSonatype
   echo "Snapshot deployed!"
 fi


### PR DESCRIPTION
### Summary of changes

 - Update Gradle files to use new maven-publish plugins
 - Update `deploy_snapshot.sh` to deploy SNAPSHOT versions
 - Fix failing unit tests by removing hard-coded theme resource 
 - Update `minSdkVersion` to 21

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire @sarahkoop 
