### PR TITLE
Revert minSdk Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 * Bump `compileSdkVersion` and `targetSdkVersion` to API level 30
 * Add `setCountryCode` to `GooglePaymentRequest`
-* Breaking Changes
-  * Bump `minSdkVersion` to 21.
 
 ## 3.3.1
 

--- a/GooglePayment/build.gradle
+++ b/GooglePayment/build.gradle
@@ -106,7 +106,7 @@ afterEvaluate {
 
                 pom {
                     name = 'google-payment'
-                    packaging = 'jar'
+                    packaging = 'aar'
                     description = 'Google Pay Module for Braintree\'s Android SDK.'
                     url = 'https://github.com/braintree/braintree-android-google-payment'
 

--- a/GooglePayment/src/main/AndroidManifest.xml
+++ b/GooglePayment/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.braintreepayments.api.googlepayment">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.braintreepayments.api.googlepayment">
+
+    <uses-sdk tools:overrideLibrary="com.braintreepayments.api,com.braintreepayments.api.core,com.paypal.android.sdk.onetouch.core,com.paypal.android.sdk" />
     <application>
-        <activity android:name="com.braintreepayments.api.GooglePaymentActivity"
-            android:theme="@style/bt_transparent_activity"/>
+        <activity
+            android:name="com.braintreepayments.api.GooglePaymentActivity"
+            android:theme="@style/bt_transparent_activity" />
     </application>
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     targetSdkVersion = 30
     versionCode = 11
     versionName = version
-    braintreeVersion = '3.14.1'
+    braintreeVersion = '3.7.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 version = '3.3.2-SNAPSHOT'
 ext {
     compileSdkVersion = 30
-    minSdkVersion = 21
+    minSdkVersion = 16
     targetSdkVersion = 30
     versionCode = 11
     versionName = version


### PR DESCRIPTION
### Summary of changes

 - Revert minSdk version back to 16 to allow for a minor version release of the SDK

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 
